### PR TITLE
Fix bug when placing '-' at start of an InputField

### DIFF
--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -51,6 +51,7 @@ func openPrompt(
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlB, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
+	c.SetRune(0, '-', handleInputFormCustomBindings)
 	promptInputField.SetInputCapture(c.Capture)
 	promptInputField.SetFieldWidth(config.MAX_WIDTH - len(label))
 	promptInputField.SetAcceptanceFunc(acceptanceFunc)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"jcb/config"
 	promptBindings "jcb/ui/prompt-bindings"
+	"strings"
 
 	"code.rocketnine.space/tslocum/cbind"
 	"code.rocketnine.space/tslocum/cview"
@@ -101,5 +102,30 @@ func handleInputFormCustomBindings(ev *tcell.EventKey) *tcell.EventKey {
 	case tcell.KeyBackspace2:
 		promptBindings.OtherUnixWordRubout(field)
 	}
+
+	// this is a workaround in a cview bug that prevents a dash from being
+	// dropped into the start of an InputField.
+	if ev.Rune() == '-' {
+		var text string
+		pos := field.GetCursorPosition()
+
+		textSlice := strings.Split(field.GetText(), "")
+		for i, c := range textSlice {
+			if i == pos {
+				text = text + "-"
+			}
+			text = text + c
+		}
+
+		if pos == len(text) {
+			text = text + "-"
+		}
+
+		field.SetText(text)
+		if pos < len(text) {
+			field.SetCursorPosition(pos + 1)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
This is a bug in cview.
