### PR TITLE
Handle all the characters

### DIFF
--- a/ui/edit.go
+++ b/ui/edit.go
@@ -157,7 +157,9 @@ func createEditForm() *cview.Form {
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlB, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
-	c.SetRune(0, '-', handleInputFormCustomBindings)
+	for _, k := range []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),./<>?;':\"[]{}-+") {
+		c.SetRune(0, k, handleInputFormCustomBindings)
+	}
 	editInputFieldDate.SetInputCapture(c.Capture)
 	editInputFieldCategory.SetInputCapture(c.Capture)
 	editInputFieldDescription.SetInputCapture(c.Capture)

--- a/ui/insert.go
+++ b/ui/insert.go
@@ -162,7 +162,9 @@ func createInsertForm() *cview.Form {
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlB, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
-	c.SetRune(0, '-', handleInputFormCustomBindings)
+	for _, k := range []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),./<>?;':\"[]{}-+") {
+		c.SetRune(0, k, handleInputFormCustomBindings)
+	}
 	insertInputFieldDate.SetInputCapture(c.Capture)
 	insertInputFieldDescription.SetInputCapture(c.Capture)
 	insertInputFieldCents.SetInputCapture(c.Capture)

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -51,7 +51,9 @@ func openPrompt(
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlB, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
-	c.SetRune(0, '-', handleInputFormCustomBindings)
+	for _, k := range []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),./<>?;':\"[]{}-+") {
+		c.SetRune(0, k, handleInputFormCustomBindings)
+	}
 	promptInputField.SetInputCapture(c.Capture)
 	promptInputField.SetFieldWidth(config.MAX_WIDTH - len(label))
 	promptInputField.SetAcceptanceFunc(acceptanceFunc)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"jcb/config"
 	promptBindings "jcb/ui/prompt-bindings"
+	"regexp"
 	"strings"
 
 	"code.rocketnine.space/tslocum/cbind"
@@ -103,22 +104,23 @@ func handleInputFormCustomBindings(ev *tcell.EventKey) *tcell.EventKey {
 		promptBindings.OtherUnixWordRubout(field)
 	}
 
-	// this is a workaround in a cview bug that prevents a dash from being
-	// dropped into the start of an InputField.
-	if ev.Rune() == '-' {
+	// this is to workaround some bugs in cview that prevents a dash editing
+	// inputs at or near symbols.
+	isChar, _ := regexp.MatchString(`[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),\./<>?;':\"\[\]\{\}\-+]`, string(ev.Rune()))
+	if isChar {
 		var text string
 		pos := field.GetCursorPosition()
 
 		textSlice := strings.Split(field.GetText(), "")
 		for i, c := range textSlice {
 			if i == pos {
-				text = text + "-"
+				text = text + string(ev.Rune())
 			}
 			text = text + c
 		}
 
 		if pos == len(text) {
-			text = text + "-"
+			text = text + string(ev.Rune())
 		}
 
 		field.SetText(text)


### PR DESCRIPTION
I found another bug in the default cview InputField, this time when inserting text directly before a `-`. I've extended the workaround to handle all the expected characters. This now means that there isn't full utf8 support, but until there is an upstream fix, it will work for english at least.

Extends #5 