### PR TITLE
Make Readline bindings behave more like Readline

### DIFF
--- a/ui/edit.go
+++ b/ui/edit.go
@@ -155,7 +155,12 @@ func createEditForm() *cview.Form {
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlD, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlF, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlB, handleInputFormCustomBindings)
+	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlK, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
+	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlY, handleInputFormCustomBindings)
+	c.SetRune(tcell.ModAlt, 'd', handleInputFormCustomBindings)
+	c.SetRune(tcell.ModAlt, 'f', handleInputFormCustomBindings)
+	c.SetRune(tcell.ModAlt, 'b', handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
 	for _, k := range []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),./<>?;':\"[]{}-+") {
 		c.SetRune(0, k, handleInputFormCustomBindings)

--- a/ui/handlers.go
+++ b/ui/handlers.go
@@ -680,6 +680,8 @@ func handleInputFormCustomBindings(ev *tcell.EventKey) *tcell.EventKey {
 			promptBindings.DeleteWord(field)
 		case 'f':
 			promptBindings.ForwardWord(field)
+		case 'b':
+			promptBindings.BackwardWord(field)
 		}
 	} else if isChar {
 		// this is to workaround some bugs in cview that prevents a dash editing

--- a/ui/handlers.go
+++ b/ui/handlers.go
@@ -678,6 +678,8 @@ func handleInputFormCustomBindings(ev *tcell.EventKey) *tcell.EventKey {
 		switch ev.Rune() {
 		case 'd':
 			promptBindings.DeleteWord(field)
+		case 'f':
+			promptBindings.ForwardWord(field)
 		}
 	} else if isChar {
 		// this is to workaround some bugs in cview that prevents a dash editing

--- a/ui/insert.go
+++ b/ui/insert.go
@@ -160,7 +160,12 @@ func createInsertForm() *cview.Form {
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlD, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlF, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlB, handleInputFormCustomBindings)
+	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlK, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
+	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlY, handleInputFormCustomBindings)
+	c.SetRune(tcell.ModAlt, 'd', handleInputFormCustomBindings)
+	c.SetRune(tcell.ModAlt, 'f', handleInputFormCustomBindings)
+	c.SetRune(tcell.ModAlt, 'b', handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
 	for _, k := range []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),./<>?;':\"[]{}-+") {
 		c.SetRune(0, k, handleInputFormCustomBindings)

--- a/ui/prompt-bindings/prompt-bindings.go
+++ b/ui/prompt-bindings/prompt-bindings.go
@@ -27,12 +27,16 @@ func DeleteChar(field *cview.InputField) {
 
 func BackwardChar(field *cview.InputField) {
 	pos := field.GetCursorPosition()
-	field.SetCursorPosition(pos - 1)
+	if pos > 0 {
+		field.SetCursorPosition(pos - 1)
+	}
 }
 
 func ForwardChar(field *cview.InputField) {
 	pos := field.GetCursorPosition()
-	field.SetCursorPosition(pos + 1)
+	if pos < len(field.GetText()) {
+		field.SetCursorPosition(pos + 1)
+	}
 }
 
 func UnixWordRubout(field *cview.InputField) {

--- a/ui/prompt-bindings/prompt-bindings.go
+++ b/ui/prompt-bindings/prompt-bindings.go
@@ -56,6 +56,13 @@ func OtherUnixWordRubout(field *cview.InputField) {
 	deleteBackwardsWithSeparators(field, separators)
 }
 
+func KillLine(field *cview.InputField) {
+	pos := field.GetCursorPosition()
+	text := field.GetText()
+	killRing = text[pos:len(text)]
+	field.SetText(text[0:pos])
+}
+
 func deleteBackwardsWithSeparators(field *cview.InputField, separators []rune) {
 	pos := field.GetCursorPosition()
 	i := 0

--- a/ui/prompt-bindings/prompt-bindings.go
+++ b/ui/prompt-bindings/prompt-bindings.go
@@ -56,11 +56,48 @@ func OtherUnixWordRubout(field *cview.InputField) {
 	deleteBackwardsWithSeparators(field, separators)
 }
 
+func DeleteWord(field *cview.InputField) {
+	separators := []rune{' ', '-', '.', '/'}
+	deleteForwardsWithSeparators(field, separators)
+}
+
 func KillLine(field *cview.InputField) {
 	pos := field.GetCursorPosition()
 	text := field.GetText()
 	killRing = text[pos:len(text)]
 	field.SetText(text[0:pos])
+}
+
+func deleteForwardsWithSeparators(field *cview.InputField, separators []rune) {
+	pos := field.GetCursorPosition()
+	i := 0
+
+	var yankString string
+
+all:
+	for pos < len(field.GetText()) {
+		if i > 0 {
+			for _, s := range separators {
+				if field.GetText()[pos] == byte(s) {
+					break all
+				}
+			}
+		}
+
+		// delete all the spaces before considering anything deleted
+		foundSeparator := false
+		for _, s := range separators {
+			if field.GetText()[pos] == byte(s) {
+				foundSeparator = true
+			}
+		}
+		if !foundSeparator {
+			i += 1
+		}
+
+		yankString += DeleteChar(field)
+	}
+	killRingInsert(yankString)
 }
 
 func deleteBackwardsWithSeparators(field *cview.InputField, separators []rune) {

--- a/ui/prompt-bindings/prompt-bindings.go
+++ b/ui/prompt-bindings/prompt-bindings.go
@@ -46,6 +46,29 @@ func ForwardChar(field *cview.InputField) {
 	}
 }
 
+func ForwardWord(field *cview.InputField) {
+	separators := []rune{' ', '-', '.', '/'}
+	foundChar := false
+
+all:
+	for field.GetCursorPosition() < len(field.GetText()) {
+		char := field.GetText()[field.GetCursorPosition()]
+		for _, s := range separators {
+			if char == byte(s) {
+				if foundChar {
+					return
+				} else {
+					ForwardChar(field)
+					continue all
+				}
+			}
+		}
+
+		foundChar = true
+		ForwardChar(field)
+	}
+}
+
 func UnixWordRubout(field *cview.InputField) {
 	separators := []rune{' '}
 	deleteBackwardsWithSeparators(field, separators)

--- a/ui/prompt-bindings/prompt-bindings.go
+++ b/ui/prompt-bindings/prompt-bindings.go
@@ -39,6 +39,29 @@ func BackwardChar(field *cview.InputField) {
 	}
 }
 
+func BackwardWord(field *cview.InputField) {
+	separators := []rune{' ', '-', '.', '/'}
+	foundChar := false
+
+all:
+	for field.GetCursorPosition() > 0 {
+		char := field.GetText()[field.GetCursorPosition()-1]
+		for _, s := range separators {
+			if char == byte(s) {
+				if foundChar {
+					return
+				} else {
+					BackwardChar(field)
+					continue all
+				}
+			}
+		}
+
+		foundChar = true
+		BackwardChar(field)
+	}
+}
+
 func ForwardChar(field *cview.InputField) {
 	pos := field.GetCursorPosition()
 	if pos < len(field.GetText()) {

--- a/ui/prompt-bindings/prompt-bindings.go
+++ b/ui/prompt-bindings/prompt-bindings.go
@@ -6,15 +6,21 @@ import (
 	"code.rocketnine.space/tslocum/cview"
 )
 
-func DeleteChar(field *cview.InputField) {
+// XXX: not a ring, but one day it might be
+var killRing string
+
+// returns the deleted character
+func DeleteChar(field *cview.InputField) string {
 	pos := field.GetCursorPosition()
 	text := field.GetText()
+	var deletedChar string
 
 	textSlice := strings.Split(text, "")
 
 	var newSlice []string
 	for i, l := range textSlice {
 		if i == pos {
+			deletedChar = l
 			continue
 		}
 
@@ -23,6 +29,7 @@ func DeleteChar(field *cview.InputField) {
 
 	field.SetText(strings.Join(newSlice, ""))
 	field.SetCursorPosition(pos)
+	return deletedChar
 }
 
 func BackwardChar(field *cview.InputField) {
@@ -53,6 +60,8 @@ func deleteBackwardsWithSeparators(field *cview.InputField, separators []rune) {
 	pos := field.GetCursorPosition()
 	i := 0
 
+	var yankString string
+
 all:
 	for pos > 0 {
 		if i > 0 {
@@ -75,7 +84,42 @@ all:
 		}
 
 		BackwardChar(field)
-		DeleteChar(field)
+		yankString += DeleteChar(field)
 		pos -= 1
 	}
+	killRingInsert(reverse(yankString))
+}
+
+func Yank(field *cview.InputField) {
+	pos := field.GetCursorPosition()
+	text := field.GetText()
+
+	var newText string
+
+	for i, l := range strings.Split(text, "") {
+		if i == pos {
+			newText += killRing
+		}
+
+		newText += l
+	}
+
+	if pos == len(text) {
+		newText += killRing
+	}
+
+	field.SetText(newText)
+	field.SetCursorPosition(pos + len(killRing))
+}
+
+func killRingInsert(s string) {
+	killRing = s
+}
+
+func reverse(s string) string {
+	var newString string
+	for i := len(s) - 1; i >= 0; i-- {
+		newString = newString + string(s[i])
+	}
+	return newString
 }

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -52,6 +52,7 @@ func openPrompt(
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlK, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlY, handleInputFormCustomBindings)
+	c.SetRune(tcell.ModAlt, 'd', handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
 	for _, k := range []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),./<>?;':\"[]{}-+") {
 		c.SetRune(0, k, handleInputFormCustomBindings)

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -49,6 +49,7 @@ func openPrompt(
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlD, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlF, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlB, handleInputFormCustomBindings)
+	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlK, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlY, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -53,6 +53,7 @@ func openPrompt(
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlY, handleInputFormCustomBindings)
 	c.SetRune(tcell.ModAlt, 'd', handleInputFormCustomBindings)
+	c.SetRune(tcell.ModAlt, 'f', handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
 	for _, k := range []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),./<>?;':\"[]{}-+") {
 		c.SetRune(0, k, handleInputFormCustomBindings)

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -50,6 +50,7 @@ func openPrompt(
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlF, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlB, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlW, handleInputFormCustomBindings)
+	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlY, handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
 	for _, k := range []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),./<>?;':\"[]{}-+") {
 		c.SetRune(0, k, handleInputFormCustomBindings)

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -54,6 +54,7 @@ func openPrompt(
 	c.SetKey(tcell.ModCtrl, tcell.KeyCtrlY, handleInputFormCustomBindings)
 	c.SetRune(tcell.ModAlt, 'd', handleInputFormCustomBindings)
 	c.SetRune(tcell.ModAlt, 'f', handleInputFormCustomBindings)
+	c.SetRune(tcell.ModAlt, 'b', handleInputFormCustomBindings)
 	c.SetKey(tcell.ModAlt, tcell.KeyBackspace2, handleInputFormCustomBindings)
 	for _, k := range []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),./<>?;':\"[]{}-+") {
 		c.SetRune(0, k, handleInputFormCustomBindings)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -98,6 +98,8 @@ func handleInputFormCustomBindings(ev *tcell.EventKey) *tcell.EventKey {
 		promptBindings.ForwardChar(field)
 	case tcell.KeyCtrlB:
 		promptBindings.BackwardChar(field)
+	case tcell.KeyCtrlK:
+		promptBindings.KillLine(field)
 	case tcell.KeyCtrlW:
 		promptBindings.UnixWordRubout(field)
 	case tcell.KeyCtrlY:

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -100,6 +100,8 @@ func handleInputFormCustomBindings(ev *tcell.EventKey) *tcell.EventKey {
 		promptBindings.BackwardChar(field)
 	case tcell.KeyCtrlW:
 		promptBindings.UnixWordRubout(field)
+	case tcell.KeyCtrlY:
+		promptBindings.Yank(field)
 	case tcell.KeyBackspace2:
 		promptBindings.OtherUnixWordRubout(field)
 	}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2,9 +2,6 @@ package ui
 
 import (
 	"jcb/config"
-	promptBindings "jcb/ui/prompt-bindings"
-	"regexp"
-	"strings"
 
 	"code.rocketnine.space/tslocum/cbind"
 	"code.rocketnine.space/tslocum/cview"
@@ -74,64 +71,4 @@ func Start() {
 
 	app.SetRoot(panels, true)
 	app.Run()
-}
-
-func handleInputFormCustomBindings(ev *tcell.EventKey) *tcell.EventKey {
-	pn, _ := panels.GetFrontPanel()
-	var field *cview.InputField
-	switch pn {
-	case "edit":
-		fieldId, _ := editForm.GetFocusedItemIndex()
-		field = editForm.GetFormItem(fieldId).(*cview.InputField)
-	case "insert":
-		fieldId, _ := insertForm.GetFocusedItemIndex()
-		field = insertForm.GetFormItem(fieldId).(*cview.InputField)
-	case "prompt":
-		fieldId, _ := promptForm.GetFocusedItemIndex()
-		field = promptForm.GetFormItem(fieldId).(*cview.InputField)
-	}
-
-	switch ev.Key() {
-	case tcell.KeyCtrlD:
-		promptBindings.DeleteChar(field)
-	case tcell.KeyCtrlF:
-		promptBindings.ForwardChar(field)
-	case tcell.KeyCtrlB:
-		promptBindings.BackwardChar(field)
-	case tcell.KeyCtrlK:
-		promptBindings.KillLine(field)
-	case tcell.KeyCtrlW:
-		promptBindings.UnixWordRubout(field)
-	case tcell.KeyCtrlY:
-		promptBindings.Yank(field)
-	case tcell.KeyBackspace2:
-		promptBindings.OtherUnixWordRubout(field)
-	}
-
-	// this is to workaround some bugs in cview that prevents a dash editing
-	// inputs at or near symbols.
-	isChar, _ := regexp.MatchString(`[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),\./<>?;':\"\[\]\{\}\-+]`, string(ev.Rune()))
-	if isChar {
-		var text string
-		pos := field.GetCursorPosition()
-
-		textSlice := strings.Split(field.GetText(), "")
-		for i, c := range textSlice {
-			if i == pos {
-				text = text + string(ev.Rune())
-			}
-			text = text + c
-		}
-
-		if pos == len(text) {
-			text = text + string(ev.Rune())
-		}
-
-		field.SetText(text)
-		if pos < len(text) {
-			field.SetCursorPosition(pos + 1)
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
- Add basic support for `<Ctrl-Y>` (it's not yet a ring so `<Alt-Y>` is unsupported).
- Improve the behaviour of `<Alt-F>` and `<Alt-B>`.